### PR TITLE
ENH: Improve same-user detection in Docker environments

### DIFF
--- a/migas/config.py
+++ b/migas/config.py
@@ -129,7 +129,7 @@ class Config:
                 cls.user_id = user_id
             except Exception:
                 cls.user_id = gen_uuid(container=cls.container)
-                print(f"Created USER ID <{cls.user_id}>")
+
         # Do not set automatically, leave to developers
         if session_id is not None:
             try:


### PR DESCRIPTION
Previously, when users were running multiple `docker run` processes, either in parallel or subsequently, each container is given a unique hostname, making our "consistent" UUID factory anything but. However, it seems `/proc/self/mountinfo` (and `/proc/1/mountinfo`) do contain some hashes of the filesystem, and are consistent between `docker run` invocations (at least with engine v20.10.14). This comes with a caveat though - spinning off a container from another image will change this hash, so **consistency has only been shown when using the same image**.

This will require a bit more testing before going live to better understand its efficacy/reliability.

## To test
- [ ] Adding mounts (consistent)
- [ ] Removing mounts
- [ ] Downgrading Docker versions