### PR TITLE
FIX: Allow `request` to handle compressed data

### DIFF
--- a/migas/conftest.py
+++ b/migas/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-TEST_ROOT = "http://localhost:8000/"
+TEST_ROOT = "http://localhost:8080/"
 TEST_ENDPOINT = f"{TEST_ROOT}graphql"
 
 

--- a/migas/request.py
+++ b/migas/request.py
@@ -2,14 +2,14 @@
 
 import json
 import os
-import typing
+from typing import Optional, Tuple, Union
 from http.client import HTTPConnection, HTTPResponse, HTTPSConnection
 from urllib.parse import urlparse
 
 from . import __version__
 from .config import logger
 
-ETResponse = typing.Tuple[int, typing.Union[dict, str]]  # status code, body
+ETResponse = Tuple[int, Union[dict, str]]  # status code, body
 
 DEFAULT_TIMEOUT = 3
 TIMEOUT_RESPONSE = (
@@ -81,7 +81,11 @@ def request(
     return response.status, body
 
 
-def _read_response(response: HTTPResponse, encoding: typing.Optional[str] = None, chunk_size: int = None) -> str:
+def _read_response(
+    response: HTTPResponse,
+    encoding: Optional[str] = None,
+    chunk_size: Optional[int] = None
+) -> str:
     """
     Read and aggregate the response body.
 

--- a/migas/tests/test_request.py
+++ b/migas/tests/test_request.py
@@ -3,11 +3,16 @@ import pytest
 from migas.request import request
 
 GET_URL = 'https://httpbin.org/get'
+GET_COMPRESSED_URL = 'https://httpbingo.org/get'
 POST_URL = 'https://httpbin.org/post'
 
 
 @pytest.mark.parametrize(
-    'method,url,query', [('POST', POST_URL, 'mydata'), ('GET', GET_URL, None)]
+    'method,url,query', [
+        ('POST', POST_URL, 'mydata'),
+        ('GET', GET_URL, None),
+        ('GET',GET_COMPRESSED_URL, None)
+    ]
 )
 def test_request_get(method, url, query):
     status, res = request(url, query=query, method=method)

--- a/migas/tests/utils.py
+++ b/migas/tests/utils.py
@@ -3,7 +3,7 @@ def _check_server_available() -> bool:
     import requests
 
     try:
-        res = requests.get('http://localhost:8000/', timeout=1)
+        res = requests.get('http://localhost:8080/', timeout=1)
     except Exception:
         print("Could not connect to server")
         return False


### PR DESCRIPTION
`request` accepts compressed data, but doesn't actual handle decompressing it.

Initially adds a test to verify a compressed response breaks things.