### PR TITLE
CI: Build server and test operations module

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -90,7 +90,12 @@ jobs:
         repository: 'nipreps/migas-server'
         path: 'migas-server'
     - name: Start up local server
-      run: MIGAS_BYPASS_RATE_LIMIT=1 docker compose -f migas-server/docker-compose.yml up -d
+      run: |
+        cd migas-server
+        pip install hatch
+        make compose-up
+      env:
+        MIGAS_BYPASS_RATE_LIMIT: '1'
     - name: Verify server is available
       run: docker port ${MIGAS_SERVER_NAME} && sleep 10
       env:


### PR DESCRIPTION
The local server was not building correctly, so the `operations` module is not being tested.