### PR TITLE
ENH: Add helper function to send breadcrumb on interp termination

### DIFF
--- a/migas/helpers.py
+++ b/migas/helpers.py
@@ -1,0 +1,53 @@
+
+import atexit
+import sys
+
+from migas.operations import add_project
+
+
+def track_exit(project: str, version: str, error_funcs: dict | None = None) -> None:
+    atexit.register(_final_breadcrumb, project, version, error_funcs)
+
+
+def _final_breadcrumb(name, version, error_funcs=None) -> dict:
+    etype, evalue, etb = None, None, None
+
+    # Python 3.12, new method
+    # MG: Cannot reproduce behavior while testing with 3.12.0
+    # if hasattr(sys, 'last_exc'):
+    #     etype, evalue, etb = sys.last_exc
+
+    # < 3.11
+    if hasattr(sys, 'last_type'):
+        etype = sys.last_type
+        evalue = sys.last_value
+        etb = sys.last_traceback
+
+    if etype:
+        ename = etype.__name__
+
+        if isinstance(error_funcs, dict) and ename in error_funcs:
+            func = error_funcs[ename]
+            kwargs = func(etype, evalue, etb)
+
+        elif ename in ('KeyboardInterrupt', 'BdbQuit'):
+            kwargs = {
+                'status': 'S',
+                'status_desc': 'Suspended',
+            }
+
+        else:
+            kwargs = {
+                'status': 'F',
+                'status_desc': 'Errored',
+                'error_type': ename,
+                'error_desc': evalue,
+            }
+    else:
+        kwargs = {
+            'status': 'C',
+            'status_desc': 'Completed',
+        }
+
+    # Final ping
+    return add_project(name, version, **kwargs)

--- a/migas/tests/conftest.py
+++ b/migas/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+import migas
+
+TEST_ROOT = "http://localhost:8080/"
+TEST_ENDPOINT = f"{TEST_ROOT}graphql"
+
+
+@pytest.fixture(scope='session')
+def endpoint() -> str:
+    return TEST_ENDPOINT
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_migas(endpoint):
+    """Ensure migas is configured to communicate with the staging app."""
+    migas.setup(endpoint=endpoint)
+
+    assert migas.config.Config._is_setup

--- a/migas/tests/test_helpers.py
+++ b/migas/tests/test_helpers.py
@@ -1,0 +1,44 @@
+import sys
+
+import pytest
+
+import migas
+from migas.tests.utils import patched_add_project
+
+
+class CustomException(Exception):
+    ...
+
+
+def sample_error_func(etype: Exception, evalue: str, etb: str):
+    ename = etype.__name__
+    if ename == "CustomException":
+        return {
+            'status': 'F',
+            'status_desc': 'Custom Error!',
+            'error_type': ename,
+            'error_desc': 'Custom Error!',
+        }
+
+
+@pytest.mark.parametrize('error_funcs,error,status,error_desc', [
+    (None, None, 'C', None),
+    (None, KeyboardInterrupt, 'S', None),
+    (None, KeyError, 'F', 'KeyError: \'foo\''),
+    ({'CustomException': sample_error_func}, CustomException, 'F', 'Custom Error!'),
+])
+def test_final_breadcrumb(monkeypatch, error_funcs, error, status, error_desc):
+
+    # do not actually call the server
+    monkeypatch.setattr(migas.operations, 'add_project', patched_add_project)
+    if error is not None:
+        monkeypatch.setattr(sys, 'last_type', error, raising=False)
+        monkeypatch.setattr(sys, 'last_value', error_desc, raising=False)
+        monkeypatch.setattr(sys, 'last_traceback', 'Traceback...', raising=False)
+
+    from migas.helpers import _final_breadcrumb
+    res = _final_breadcrumb('nipreps/migas-py', '0.0.1', error_funcs)
+
+    assert res.get('status') == status
+    if error_desc is not None:
+        assert res.get('error_desc') == error_desc

--- a/migas/tests/utils.py
+++ b/migas/tests/utils.py
@@ -13,4 +13,7 @@ def _check_server_available() -> bool:
     return True
 
 
+def patched_add_project(project: str, project_version: str, **kwargs) -> dict:
+    return kwargs
+
 do_server_tests = _check_server_available()


### PR DESCRIPTION
This PR adds a new method  (`track_exit`) that will send a final status ping upon termination of the python interpreter.

The core of this has already been implemented in fmriprep / mriqc, but this will serve to remove all the extra code currently required, while identifying and distinguishing certain errors (Keyboard Interrupts for now, but can be expanded on using `error_funcs`.