### PR TITLE
FIX: Do not accept brotli-compressed responses

### DIFF
--- a/migas/request.py
+++ b/migas/request.py
@@ -40,7 +40,7 @@ def request(
     conn = Connection(purl.netloc, timeout=timeout)
     headers = {
         'User-Agent': f'migas-client/{__version__}',
-        'Accept-Encoding': 'gzip, deflate, br',
+        'Accept-Encoding': 'gzip, deflate',
         'Accept': '*/*',
     }
     body = None


### PR DESCRIPTION
This would currently add a new dependency.
When `br` support is included in the standard lib, this can added back.