### PR TITLE
FEAT: Add new operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,32 +28,58 @@ import migas; migas.setup(endpoint='your-endpoint')
 
 `migas` includes the following functions to communicate with the telemetry server:
 
-#### migas.add_project()
-
+#### migas.add_breadcrumb() {#addbreadcrumb}
 Send a breadcrumb with usage information to the server.
-Usage information includes:
- - application
- - application version
- - application status
 
-The server will attempt to return version information about the project.
+##### Mandatory
+- `project` - application name
+- `project_version` - application version
+
+##### Optional
+- `language` (auto-detected)
+- `language_version` (auto-detected)
+- process:
+  - `status`
+  - `status_desc`
+  - `error_type`
+  - `error_desc`
+- context:
+  - `user_id` (auto-generated)
+  - `session_id`
+  - `user_type`
+  - `platform` (auto-detected)
+  - `container` (auto-detected)
+  - `is_ci` (auto-detected)
 
 <details>
-<summary>add_project example</summary>
+<summary>add_breadcrumb example</summary>
 
 ```python
->>> add_project('nipreps/migas-py', '0.0.1')
-{'bad_versions': [],
- 'cached': True,
- 'latest_version': '0.0.4',
- 'message': '',
- 'success': True}
+>>> add_breadcrumb('nipreps/migas-py', '0.0.1', status='R', status_desc='Finished long step')
+{'success': True}
 ```
 
 </details>
 
+#### migas.check_project() {#checkproject}
+Check a project version against later developments.
 
-#### migas.get_usage()
+##### Mandatory
+- `project`
+- `project_version`
+
+
+<details>
+<summary>check_project example</summary>
+
+```python
+>>> check_project('nipreps/migas-py', '0.0.1')
+{'success': True, 'flagged': False, 'latest': '0.4.0', 'message': ''}
+```
+
+</details>
+
+#### migas.get_usage() {#getusage}
 
 Check number of uses a `project` has received from a start date, and optionally an end date.
 If no end date is specified, the current datetime is used.
@@ -69,10 +95,11 @@ If no end date is specified, the current datetime is used.
 </details>
 
 
-#### migas.track_exit()
+#### migas.track_exit() {#trackexit}
 
 Register an exit function to send a final ping upon termination of the Python interpretter.
-The inputs are equivalent to `add_project()`.
+Useful when monitoring a process that may preemptively error.
+The inputs are equivalent to [`add_breadcrumb()`](#addbreadcrumb)
 
 ## User Control
 

--- a/migas/operations.py
+++ b/migas/operations.py
@@ -22,12 +22,13 @@ class Operation:
     query_args: dict
     selections: tuple | None = None
     query: str = ''
-    _fingerprint: bool = False
+    fingerprint: bool = False
+    error_response: dict | None = None
 
     @classmethod
     def generate_query(cls, *args, **kwargs) -> str:
         parameters = _introspec(cls.generate_query, locals())
-        params = Config.populate() if cls._fingerprint else {}
+        params = Config.populate() if cls.fingerprint else {}
         params = {**params, **kwargs, **parameters}
         query = cls._construct_query(params)
         return query
@@ -63,7 +64,7 @@ class AddBreadcrumb(Operation):
             "error_desc": FREE,
         },
     }
-    _fingerprint = True
+    fingerprint = True
 
 
 @telemetry_enabled
@@ -73,7 +74,7 @@ def add_breadcrumb(project: str, project_version: str, **kwargs) -> dict:
     )
     logger.debug(query)
     _, response = request(Config.endpoint, query=query)
-    res = _filter_response(response, AddBreadcrumb.operation_name, AddBreadcrumb._error_response)
+    res = _filter_response(response, AddBreadcrumb.operation_name, AddBreadcrumb.error_response)
     return res
 
 
@@ -99,8 +100,8 @@ class AddProject(Operation):
             "arguments": FREE,
         },
     }
-    _fingerprint = True
-    _error_response = {
+    fingerprint = True
+    error_response = {
         "success": False,
         "latest_version": None,
         "message": ERROR,
@@ -134,7 +135,7 @@ def add_project(project: str, project_version: str, **kwargs) -> dict:
     query = AddProject.generate_query(project=project, project_version=project_version, **kwargs)
     logger.debug(query)
     _, response = request(Config.endpoint, query=query)
-    res = _filter_response(response, AddProject.operation_name, AddProject._error_response)
+    res = _filter_response(response, AddProject.operation_name, AddProject.error_response)
     return res
 
 

--- a/migas/operations.py
+++ b/migas/operations.py
@@ -3,106 +3,102 @@ Create queries and mutations to be sent to the graphql endpoint.
 """
 from __future__ import annotations
 
+import dataclasses
 import typing as ty
+import warnings
 
 from migas.config import Config, logger, telemetry_enabled
 from migas.request import request
 
-
-DEFAULT_ERROR = '[migas-py] An error occurred.'
-
-
-class OperationTemplate(ty.TypedDict):
-    operation: str
-    args: dict
-    response: dict
+free = '"{}"'  # free text fields
+fixed = '{}'  # fixed text fields
 
 
-getUsage: OperationTemplate = {
-    "operation": "query{get_usage($)}",
-    "args": {
-        # required
-        "project": '"{}"',
-        "start": '"{}"',
-        # optional
-        "end": '"{}"',
-        "unique": "{}",
-    },
-    "response": {
-        'success': False,
-        'hits': 0,
-        'message': DEFAULT_ERROR,
-    },
-}
+@dataclasses.dataclass
+class Operation:
+    operation_type: str
+    operation_name: str
+    query_args: dict
+    selections: tuple | None = None
+    query: str = ''
+    _fingerprint: bool = False
 
+    @classmethod
+    def generate_query(cls, *args, **kwargs) -> str:
+        parameters = _introspec(cls.generate_query, locals())
+        params = Config.populate() if cls._fingerprint else {}
+        params = {**params, **kwargs, **parameters}
+        query = cls._construct_query(params)
+        return query
+
+    @classmethod
+    def _construct_query(cls, params: dict) -> str:
+        """Construct the graphql query."""
+        query = _parse_format_params(params, cls.query_args)
+        cls.query = f'{cls.operation_type}{{{cls.operation_name}({query})}}'
+        return cls.query
+
+
+class AddBreadcrumb(Operation):
+    operation_type = "mutation"
+    operation_name = "add_breadcrumb"
+    query_args = {
+        "project": free,
+        "project_version": free,
+        "language": free,
+        "language_version": free,
+        "ctx": {
+            "session_id": free,
+            "user_id": free,
+            "user_type": fixed,
+            "platform": free,
+            "container": fixed,
+            "is_ci": fixed,
+        },
+        "proc": {
+            "status": fixed,
+            "status_desc": free,
+            "error_type": free,
+            "error_desc": free,
+        },
+    }
+    _fingerprint = True
 
 @telemetry_enabled
-def get_usage(
-    project: str,
-    start: str,
-    end: str = None,
-    unique: bool = False,
-) -> dict:
-    """
-    Query project usage.
-
-    This function requires a `project`, which is a string in the format of the GitHub
-    `{owner}/{repository}`, and the start date to collect information.
-
-    Additionally, an end date can be provided, or the current datetime will be used.
-
-    `start` and `end` can be in either of the following formats:
-        - YYYY-MM-DD
-        - YYYY-MM-DDTHH:MM:SSZ
-
-    If `unique` is set to `True`, aggregates multiple uses by the same user as a single use.
-
-    Returns
-    -------
-    A dictionary containing the number of hits a project received.
-    """
-    params = _introspec(get_usage, locals())
-    query = _formulate_query(params, getUsage)
+def add_breadcrumb(project: str, project_version: str, **kwargs) -> dict:
+    query = AddBreadcrumb.generate_query(project=project, project_version=project_version, **kwargs)
     logger.debug(query)
     _, response = request(Config.endpoint, query=query)
-    res = _filter_response(response, 'get_usage', getUsage["response"])
+    res = _filter_response(response, AddBreadcrumb.operation_name)
     return res
 
 
-addProject: OperationTemplate = {
-    "operation": "mutation{add_project(p:{$})}",
-    "args": {
-        # required
-        "project": '"{}"',
-        "project_version": '"{}"',
-        "language": '"{}"',
-        "language_version": '"{}"',
-        "is_ci": '{}',
-        # optional
-        "status": "{}",
-        "status_desc": '"{}"',
-        "error_type": '"{}"',
-        "error_desc": '"{}"',
-        "user_id": '"{}"',
-        "session_id": '"{}"',
-        "container": "{}",
-        "platform": '"{}"',
-        "arguments": '"{}"',
-    },
-    "response": {
-        'success': False,
-        'message': DEFAULT_ERROR,
-        'latest_version': None,
-    },
-}
-
+class AddProject(Operation):
+    operation_type = "mutation"
+    operation_name = "add_project"
+    query_args = {
+        "p": {
+            "project": free,
+            "project_version": free,
+            "language": free,
+            "language_version": free,
+            "is_ci": fixed,
+            "status": fixed,
+            "status_desc": free,
+            "error_type": free,
+            "error_desc": free,
+            "user_id": free,
+            "session_id": free,
+            "container": fixed,
+            "user_type": fixed,
+            "platform": free,
+            "arguments": free,
+        },
+    }
+    _fingerprint = True
 
 @telemetry_enabled
-def add_project(
-    project: str,
-    project_version: str,
-    **kwargs,
-) -> dict:
+def add_project(project: str, project_version: str, **kwargs) -> dict:
     """
     Send project usage information to the telemetry server.
 
@@ -120,14 +116,66 @@ def add_project(
     A dictionary containing the latest released version of the project,
     as well as any messages sent by the developers.
     """
-    parameters = _introspec(add_project, locals())
-    # TODO: 3.9 - Replace with | operator
-    params = {**Config.populate(), **kwargs, **parameters}
-    query = _formulate_query(params, addProject)
+    warnings.warn(
+        "This method has been separated into `add_breadcrumb` and `check_project` methods.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    query = AddProject.generate_query(project=project, project_version=project_version, **kwargs)
     logger.debug(query)
     _, response = request(Config.endpoint, query=query)
-    res = _filter_response(response, 'add_project', addProject["response"])
+    res = _filter_response(response, AddProject.operation_name, {})
     return res
+
+class CheckProject(Operation):
+    operation_type = "query"
+    operation_name = "check_project"
+    query_args = {
+        "project": free,
+        "project_version": free,
+        "language": free,
+        "language_version": free,
+        "is_ci": fixed,
+        "status": fixed,
+        "status_desc": free,
+        "error_type": free,
+        "error_desc": free,
+        "user_id": free,
+        "session_id": free,
+        "container": fixed,
+        "platform": free,
+        "arguments": free,
+    }
+
+
+@telemetry_enabled
+def check_project(project: str, project_version: str, **kwargs) -> dict:
+    query = CheckProject.generate_query(project=project, project_version=project_version, **kwargs)
+    logger.debug(query)
+    _, response = request(Config.endpoint, query=query)
+    res = _filter_response(response, CheckProject.operation_name)
+    return res
+
+
+
+class GetUsage(Operation):
+    operation_type = 'query'
+    operation_name = 'get_usage'
+    query_args = {
+        "project": free,
+        "start": free,
+        "end": free,
+        "unique": fixed,
+    }
+
+@telemetry_enabled
+def get_usage(project: str, start: str, **kwargs) -> dict:
+        query = GetUsage.generate_query(project=project, start=start, **kwargs)
+        logger.debug(query)
+        _, response = request(Config.endpoint, query=query)
+        res = _filter_response(response, GetUsage.operation_name)
+        return res
+
 
 
 def _introspec(func: ty.Callable, func_locals: dict) -> dict:
@@ -142,24 +190,13 @@ def _introspec(func: ty.Callable, func_locals: dict) -> dict:
     }
 
 
-def _formulate_query(params: dict, template: OperationTemplate) -> str:
-    """Construct the graphql query."""
-    query_params = {}
-    for template_arg in template["args"]:
-        if template_arg in params:
-            value = params[template_arg]
-            if isinstance(value, bool):
-                # booleans must be properly formatted
-                value = str(value).lower()
-            query_params[template_arg] = template["args"][template_arg].format(value)
+def _filter_response(response: dict | str, operation: str, fallback: dict | None = None):
+    if not fallback:
+        fallback = {
+            'success': False,
+            'message': '[migas-py] An error occurred.',
+        }
 
-    query = template["operation"].replace(
-        "$", ",".join([f"{x}:{y}" for x, y in query_params.items()])
-    )
-    return query
-
-
-def _filter_response(response: dict | str, operation: str, fallback: dict):
     if isinstance(response, dict):
         res = response.get("data")
         # success
@@ -171,3 +208,22 @@ def _filter_response(response: dict | str, operation: str, fallback: dict):
         fallback['message'] = response.get('errors')[0]['message']
     finally:
         return fallback
+
+
+def _parse_format_params(params: dict, query_args: dict) -> str:
+    query_inputs = []
+    vals = None
+
+    for qarg, qval in query_args.items():
+        if qarg in params:
+            val = params[qarg]
+            if isinstance(val, bool):
+                val = str(val).lower()
+            val = qval.format(val)
+            query_inputs.append(f'{qarg}:{val}')
+
+        elif isinstance(qval, dict):
+            vals = _parse_format_params(params, qval)
+            query_inputs.append(f'{qarg}:{{{vals}}}')
+
+    return ','.join(query_inputs)

--- a/migas/operations.py
+++ b/migas/operations.py
@@ -20,7 +20,7 @@ class Operation:
     operation_type: str
     operation_name: str
     query_args: dict
-    selections: tuple | None = None
+    selections: tuple | None = None  # TODO: Add subfield selection support
     query: str = ''
     fingerprint: bool = False
     error_response: dict | None = None
@@ -37,7 +37,10 @@ class Operation:
     def _construct_query(cls, params: dict) -> str:
         """Construct the graphql query."""
         query = _parse_format_params(params, cls.query_args)
-        cls.query = f'{cls.operation_type}{{{cls.operation_name}({query})}}'
+        cls.query = f'{cls.operation_type}{{{cls.operation_name}({query})'
+        if cls.selections:
+            cls.query += f'{{{",".join(f for f in cls.selections)}}}'
+        cls.query += '}'
         return cls.query
 
 
@@ -65,6 +68,7 @@ class AddBreadcrumb(Operation):
         },
     }
     fingerprint = True
+    selections = ('success',)
 
 
 @telemetry_enabled
@@ -158,6 +162,7 @@ class CheckProject(Operation):
         "platform": FREE,
         "arguments": FREE,
     }
+    selections = ('success', 'flagged', 'latest', 'message')
 
 
 @telemetry_enabled

--- a/migas/tests/conftest.py
+++ b/migas/tests/conftest.py
@@ -13,3 +13,4 @@ def setup_migas():
     migas.setup(endpoint=TEST_ENDPOINT)
 
     assert migas.config.Config._is_setup
+    return migas.config.Config._is_setup

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -111,8 +111,13 @@ def test_print_config(capsys):
 
 def test_logger(monkeypatch):
     logger = config.logger
-    assert logger.name == 'migas-py'
-    assert logger.level == 30
-    monkeypatch.setenv("MIGAS_LOG_LEVEL", "INFO")
-    config._init_logger()
-    assert logger.level == 20
+    with monkeypatch.context() as m:
+        m.delenv("MIGAS_LOG_LEVEL")
+        config._init_logger()
+        assert logger.name == 'migas-py'
+        assert logger.level == 30
+
+    with monkeypatch.context() as m:
+        m.setenv("MIGAS_LOG_LEVEL", "INFO")
+        config._init_logger()
+        assert logger.level == 20

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -112,7 +112,7 @@ def test_print_config(capsys):
 def test_logger(monkeypatch):
     logger = config.logger
     with monkeypatch.context() as m:
-        m.delenv("MIGAS_LOG_LEVEL")
+        m.delenv("MIGAS_LOG_LEVEL", raising=False)
         config._init_logger()
         assert logger.name == 'migas-py'
         assert logger.level == 30

--- a/migas/tests/test_operations.py
+++ b/migas/tests/test_operations.py
@@ -3,10 +3,16 @@ from datetime import timedelta
 from datetime import timezone as tz
 import time
 
+from looseversion import LooseVersion
 import pytest
 
 from migas import __version__
-from migas.operations import add_breadcrumb, add_project, get_usage
+from migas.operations import (
+    add_breadcrumb,
+    add_project,
+    check_project,
+    get_usage,
+)
 
 from .utils import do_server_tests
 
@@ -75,3 +81,14 @@ def test_add_project(setup_migas):
     res = add_project(test_project, __version__, status='wtf')
     assert res['success'] is False
     assert res['latest_version'] is None
+
+
+def test_check_project(setup_migas):
+    res = check_project(test_project, __version__)
+    assert res['success'] is True
+    assert res['latest']
+    v = LooseVersion(__version__)
+    latest = LooseVersion(res['latest'])
+    assert v >= latest
+    assert res['flagged'] is False
+    assert res['message'] == ''

--- a/migas/tests/test_operations.py
+++ b/migas/tests/test_operations.py
@@ -6,7 +6,7 @@ import time
 import pytest
 
 from migas import __version__
-from migas.operations import add_project, get_usage
+from migas.operations import add_breadcrumb, add_project, get_usage
 
 from .utils import do_server_tests
 
@@ -20,31 +20,25 @@ today = today.strftime('%Y-%m-%d')
 
 
 def test_operations(setup_migas):
-    _test_add_project()
+    _test_add_breakcrumb()
     # add delay to ensure server has updated
     time.sleep(2)
     _test_get_usage()
 
-def _test_add_project():
-    res = add_project(test_project, __version__)
+def _test_add_breakcrumb():
+    res = add_breadcrumb(test_project, __version__)
     assert res['success'] is True
-    latest = res['latest_version']
-    assert latest
 
     # ensure kwargs can be submitted
-    res = add_project(test_project, __version__, language='cpython', platform='win32')
+    res = add_breadcrumb(test_project, __version__, language='cpython', platform='win32')
     assert res['success'] is True
-    assert res['latest_version'] == latest
-    # should be cached since we just checked the version
-    assert res['cached'] is True
 
-    # illegal queries should fail
-    res = add_project(test_project, __version__, status='wtf')
+    # validation should happen instantly
+    res = add_breadcrumb(test_project, __version__, status='wtf')
     assert res['success'] is False
-    assert res['latest_version'] is None
 
 def _test_get_usage():
-    """This test requires `_test_add_project()` to be run before."""
+    """This test requires `_test_add_breadcrumb()` to be run before."""
     res = get_usage(test_project, start=today)
     assert res['success'] is True
     all_usage = res['hits']
@@ -62,3 +56,22 @@ def _test_get_usage():
     res = get_usage('my/madeup-project', start=today)
     assert res['success'] is False
     assert res['hits'] == 0
+
+
+def test_add_project(setup_migas):
+    res = add_project(test_project, __version__)
+    assert res['success'] is True
+    latest = res['latest_version']
+    assert latest
+
+    # ensure kwargs can be submitted
+    res = add_project(test_project, __version__, language='cpython', platform='win32')
+    assert res['success'] is True
+    assert res['latest_version'] == latest
+    # should be cached since we just checked the version
+    assert res['cached'] is True
+
+    # illegal queries should fail
+    res = add_project(test_project, __version__, status='wtf')
+    assert res['success'] is False
+    assert res['latest_version'] is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
 test = [
     "requests",
     "pytest",
+    "looseversion",
 ]
 
 #


### PR DESCRIPTION
- Adds `add_breadcrumb` and `check_project` methods, which separate out the behavior given by `add_project`.
  - Deprecates `add_project`
- Refactors the query/mutation generation into a base class, which is then altered by the operation specific parameters