### PR TITLE
FIX: Set cap on nipype traceback

### DIFF
--- a/migas/error/nipype.py
+++ b/migas/error/nipype.py
@@ -3,6 +3,8 @@ from types import TracebackType
 
 from migas.error import strip_filenames
 
+MAX_TRACEBACK_SIZE = 1500
+
 
 def node_execution_error(etype: type, evalue: str, etb: TracebackType) -> dict:
     strpval = evalue.replace('\n', ' ').replace('\t', ' ').strip()
@@ -22,6 +24,9 @@ def node_execution_error(etype: type, evalue: str, etb: TracebackType) -> dict:
 
     if m := re.search(r'(?P<tb>(?<=Traceback:).*)', strpval):
         tb = strip_filenames(m.group('tb')).strip()
+        # cap traceback size to avoid massive request
+        if len(tb) > 1500:
+            tb = f'{tb[:747]}...{tb[-750:]}'
 
     return {
         'status': 'F',

--- a/migas/error/tests/test_nipype.py
+++ b/migas/error/tests/test_nipype.py
@@ -1,6 +1,6 @@
 import sys
 
-from migas.error.nipype import node_execution_error
+from migas.error.nipype import node_execution_error, MAX_TRACEBACK_SIZE
 
 ERROR_TEXT = """
 nipype.pipeline.engine.nodes.NodeExecutionError: Exception raised while executing Node failingnode.
@@ -63,3 +63,4 @@ def test_node_execution_error():
     assert kwargs['status'] == 'F'
     assert kwargs['error_type'] == 'NodeExecutionError'
     assert 'FileNotFoundError' in kwargs['error_desc']
+    assert len(kwargs['error_desc']) <= MAX_TRACEBACK_SIZE


### PR DESCRIPTION
Sets the maximum traceback size to avoid excessively long requests - the most important information will be at the beginning / end of the traceback.